### PR TITLE
Solucionado imagen icono invisible

### DIFF
--- a/vistas/MainView.py
+++ b/vistas/MainView.py
@@ -32,8 +32,8 @@ class MainView():
         self.entry_search = tk.Entry(search_frame)
         self.entry_search.pack(side="left", padx=5)
         image = Image.open("./assets/lupa.png").resize((50, 50))
-        image_tk   = ImageTk.PhotoImage(image)
-        button = tk.Button(search_frame, text="Buscar",image=image_tk, compound="right", command=self.buscar_productos)
+        self.image_tk   = ImageTk.PhotoImage(image)
+        button = tk.Button(search_frame, text="Buscar",image=self.image_tk, compound="right", command=self.buscar_productos)
         button.pack(side="left")
 
     def load_productos(self):


### PR DESCRIPTION
La variable img_tk debe mantenerse referenciada mientras el botón esté en uso. Si img_tk se elimina o se sale del alcance, la imagen no se mostrará.

Al usar self.img_tk, creamos un atributo de instancia de la clase. Esto significa que la variable img_tk estará disponible para cualquier método de esa instancia de la clase mientras el objeto exista. 

De esta manera el botón podrá acceder a la imagen en cualquier momento, incluso después de que se haya ejecutado el método que la creó.